### PR TITLE
Refactored the Output class to allow for score aggregation across layers

### DIFF
--- a/multixrank/Output.py
+++ b/multixrank/Output.py
@@ -6,7 +6,7 @@ from scipy.stats import stats
 
 class Output:
 
-    def __init__(self, rwr_df, multiplexall, top: int, aggregation: str):
+    def __init__(self, rwr_df, multiplexall, top: int, top_type: str, aggregation: str):
 
         self.rwr_result_list = rwr_df
         self.multiplexall = multiplexall
@@ -44,7 +44,10 @@ class Output:
         #######################################################################
 
         if not (top is None):
-            self._df = self._df.groupby('multiplex').head(top)
+            if (top_type == "per layer"):
+                self._df = self._df.groupby('multiplex').head(top)
+            if (top_type == "all"):
+                self._df = self._df.head(top)
 
     def to_sif(self, bipartiteall, path: str):
         pathlib.Path(os.path.dirname(path)).mkdir(exist_ok=True, parents=True)

--- a/multixrank/Output.py
+++ b/multixrank/Output.py
@@ -6,19 +6,36 @@ from scipy.stats import stats
 
 class Output:
 
-    def __init__(self, rwr_df, multiplexall, top: int):
+    def __init__(self, rwr_df, multiplexall, top: int, aggregation: str):
 
         self.rwr_result_list = rwr_df
         self.multiplexall = multiplexall
 
         self._df = rwr_df
 
-        multiplex_node_prob_zero_df = self._df.loc[self._df.score == 0][['multiplex', 'node']].drop_duplicates()
+        self.aggregation = aggregation
+
+        if (self.aggregation != "none"):
+            multiplex_node_prob_zero_df = self._df.loc[self._df.score == 0][['multiplex', 'node']].drop_duplicates()
+        if (self.aggregation == "none"):
+            multiplex_node_prob_zero_df = self._df.loc[self._df.score == 0][['multiplex', 'layer', 'node']]
+
         multiplex_node_prob_zero_df['score'] = 0
-        self._df = (self._df.loc[self._df.score > 0]).groupby(['multiplex', 'node']).agg({'score': stats.gmean}).reset_index()
+
+        if (self.aggregation == "geometric mean"):
+            self._df = (self._df.loc[self._df.score > 0]).groupby(['multiplex', 'node']).agg({'score': stats.gmean}).reset_index()
+        if (self.aggregation == "sum"):
+            self._df = (self._df.loc[self._df.score > 0]).groupby(['multiplex', 'node']).agg({'score': sum}).reset_index()
+        if (self.aggregation == "none"):
+            self._df = (self._df.loc[self._df.score > 0])
+        
         self._df = pandas.concat([multiplex_node_prob_zero_df, self._df], axis=0)
-        self._df = self._df.drop_duplicates(['multiplex', 'node'], keep='first')
-        self._df.sort_values('score', ascending=False, inplace=True)
+
+        if (self.aggregation != "none"):
+            self._df = self._df.drop_duplicates(['multiplex', 'node'], keep='first')
+            self._df.sort_values('score', ascending=False, inplace=True)
+        else:
+            self._df.sort_values(by=['multiplex', 'score'], ascending=[True,False], inplace=True)
 
         #######################################################################
         #

--- a/multixrank/__init__.py
+++ b/multixrank/__init__.py
@@ -170,15 +170,22 @@ class Multixrank(object):
         output_obj = Output(random_walk_rank, self.multiplexall_obj, top=top, aggregation=aggregation)
         output_obj.to_tsv(outdir=path, degree=degree)
 
-    def to_sif(self, random_walk_rank: pandas.DataFrame, path: str, top: int = None):
+    def to_sif(self, random_walk_rank: pandas.DataFrame, path: str, top: int = None, aggregation: str = 'geometric mean'):
         """Writes the 'random walk results' to a subnetwork with the 'top' nodes as a SIF format (See Cytoscape documentation)
 
         Args:
             rwr_ranking_df (pandas.DataFrame) : A pandas Dataframe with columns: multiplex, node, layer, score, which is the output of the random_walk_rank function
             path (str): Path to the TSV file with the random walk results
             top (int): Top nodes based on the random walk score to be included in the TSV file
+            aggregation (str): One of "none", "geometric mean" or "sum"
         """
-        output_obj = Output(random_walk_rank, self.multiplexall_obj, top=top)
+
+        if not (aggregation in ['none', 'geometric mean', 'sum']):
+            logger.error('Aggregation parameter must take one of these values: "none", "geometric mean" or "sum". '
+                         'Current value: {}'.format(aggregation))
+            sys.exit(1)
+
+        output_obj = Output(random_walk_rank, self.multiplexall_obj, top=top, aggregation=aggregation)
         pathlib.Path(os.path.dirname(path)).mkdir(exist_ok=True, parents=True)
         output_obj.to_sif(path=path, bipartiteall=self.bipartiteall_obj)
 

--- a/multixrank/__init__.py
+++ b/multixrank/__init__.py
@@ -152,15 +152,22 @@ class Multixrank(object):
 
         return rwr_ranking_df
 
-    def write_ranking(self, random_walk_rank: pandas.DataFrame, path: str, top: int=None, degree: bool=False):
+    def write_ranking(self, random_walk_rank: pandas.DataFrame, path: str, top: int=None, aggregation: str="geometric mean", degree: bool=False):
         """Writes the 'random walk results' to a subnetwork with the 'top' nodes as a SIF format (See Cytoscape documentation)
 
         Args:
             rwr_ranking_df (pandas.DataFrame) : A pandas Dataframe with columns: multiplex, node, layer, score, which is the output of the random_walk_rank function
             path (str): Path to the SIF file
             top (int): Top nodes based on the random walk score to be included in the SIF file
+            aggregation (str): One of "none", "geometric mean" or "sum"
         """
-        output_obj = Output(random_walk_rank, self.multiplexall_obj, top=top)
+
+        if not (aggregation in ['none', 'geometric mean', 'sum']):
+            logger.error('Aggregation parameter must take one of these values: "none", "geometric mean" or "sum". '
+                         'Current value: {}'.format(aggregation))
+            sys.exit(1)
+        
+        output_obj = Output(random_walk_rank, self.multiplexall_obj, top=top, aggregation=aggregation)
         output_obj.to_tsv(outdir=path, degree=degree)
 
     def to_sif(self, random_walk_rank: pandas.DataFrame, path: str, top: int = None):

--- a/multixrank/__init__.py
+++ b/multixrank/__init__.py
@@ -167,16 +167,17 @@ class Multixrank(object):
                          'Current value: {}'.format(aggregation))
             sys.exit(1)
         
-        output_obj = Output(random_walk_rank, self.multiplexall_obj, top=top, aggregation=aggregation)
+        output_obj = Output(random_walk_rank, self.multiplexall_obj, top=top, top_type="per layer", aggregation=aggregation)
         output_obj.to_tsv(outdir=path, degree=degree)
 
-    def to_sif(self, random_walk_rank: pandas.DataFrame, path: str, top: int = None, aggregation: str = 'geometric mean'):
+    def to_sif(self, random_walk_rank: pandas.DataFrame, path: str, top: int = None, top_type: str = 'per layer', aggregation: str = 'geometric mean'):
         """Writes the 'random walk results' to a subnetwork with the 'top' nodes as a SIF format (See Cytoscape documentation)
 
         Args:
             rwr_ranking_df (pandas.DataFrame) : A pandas Dataframe with columns: multiplex, node, layer, score, which is the output of the random_walk_rank function
             path (str): Path to the TSV file with the random walk results
             top (int): Top nodes based on the random walk score to be included in the TSV file
+            top_type (str): "per layer" (top nodes for each layer) or "all" (top nodes any layer)
             aggregation (str): One of "none", "geometric mean" or "sum"
         """
 
@@ -185,7 +186,12 @@ class Multixrank(object):
                          'Current value: {}'.format(aggregation))
             sys.exit(1)
 
-        output_obj = Output(random_walk_rank, self.multiplexall_obj, top=top, aggregation=aggregation)
+        if not (top_type in ['per layer', 'all']):
+            logger.error('top_type parameter must take one of these values: "per layer" or "all". '
+                         'Current value: {}'.format(top_type))
+            sys.exit(1)
+        
+        output_obj = Output(random_walk_rank, self.multiplexall_obj, top=top, top_type=top_type, aggregation=aggregation)
         pathlib.Path(os.path.dirname(path)).mkdir(exist_ok=True, parents=True)
         output_obj.to_sif(path=path, bipartiteall=self.bipartiteall_obj)
 


### PR DESCRIPTION
Refactored the Output class to allow for score aggregation across layers, with a new `aggregation` parameter that can be set to `none` (to output layer-specific node scores), `sum` (to sum the scores of nodes across layers), or `geometric mean` (the default aggregation method that was already implemented). The changes were made to the `__init__.py` and `Output.py` files.